### PR TITLE
Add diagnostic for invalid address bins

### DIFF
--- a/CommonLibF4/src/REL/Relocation.cpp
+++ b/CommonLibF4/src/REL/Relocation.cpp
@@ -44,8 +44,93 @@
 
 #include <Windows.h>
 
+#include <bcrypt.h>
+
+#define NT_SUCCESS(a_status) (a_status >= 0)
+
+#include "F4SE/Logger.h"
+
 namespace REL
 {
+	namespace log = F4SE::log;
+
+	namespace detail
+	{
+		std::optional<std::string> sha512(std::span<const std::byte> a_data)
+		{
+			::BCRYPT_ALG_HANDLE algorithm;
+			if (!NT_SUCCESS(::BCryptOpenAlgorithmProvider(
+					&algorithm,
+					BCRYPT_SHA512_ALGORITHM,
+					nullptr,
+					0))) {
+				log::error("failed to open algorithm provider");
+				return std::nullopt;
+			}
+			const stl::scope_exit delAlgorithm([&]() {
+				[[maybe_unused]] const auto success = NT_SUCCESS(::BCryptCloseAlgorithmProvider(algorithm, 0));
+				assert(success);
+			});
+
+			::BCRYPT_HASH_HANDLE hash;
+			if (!NT_SUCCESS(::BCryptCreateHash(
+					algorithm,
+					&hash,
+					nullptr,
+					0,
+					nullptr,
+					0,
+					0))) {
+				log::error("failed to create hash");
+				return std::nullopt;
+			}
+			const stl::scope_exit delHash([&]() {
+				[[maybe_unused]] const auto success = NT_SUCCESS(::BCryptDestroyHash(hash));
+				assert(success);
+			});
+
+			if (!NT_SUCCESS(::BCryptHashData(
+					hash,
+					reinterpret_cast<::PUCHAR>(const_cast<std::byte*>(a_data.data())),  // does not modify contents of buffer
+					static_cast<::ULONG>(a_data.size()),
+					0))) {
+				log::error("failed to hash data");
+				return std::nullopt;
+			}
+
+			::DWORD hashLen = 0;
+			::ULONG discard = 0;
+			if (!NT_SUCCESS(::BCryptGetProperty(
+					hash,
+					BCRYPT_HASH_LENGTH,
+					reinterpret_cast<::PUCHAR>(&hashLen),
+					sizeof(hashLen),
+					&discard,
+					0))) {
+				log::error("failed to get property");
+				return std::nullopt;
+			}
+			std::vector<::UCHAR> buffer(static_cast<std::size_t>(hashLen));
+
+			if (!NT_SUCCESS(::BCryptFinishHash(
+					hash,
+					buffer.data(),
+					static_cast<::ULONG>(buffer.size()),
+					0))) {
+				log::error("failed to finish hash");
+				return std::nullopt;
+			}
+
+			std::string result;
+			result.reserve(buffer.size() * 2);
+			for (const auto byte : buffer) {
+				result += fmt::format("{:02X}", byte);
+			}
+
+			return { std::move(result) };
+		}
+	}
+
 	void Module::load_segments()
 	{
 		auto dosHeader = reinterpret_cast<const ::IMAGE_DOS_HEADER*>(_base);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,8 +13,5 @@
     "spdlog",
     "srell",
     "xbyak"
-  ],
-  "vcpkg-configuration": {
-    "overlay-ports": [ "./cmake/ports/" ]
-  }
+  ]
 }


### PR DESCRIPTION
I accidentally released the address bin for v1.10.980 without sorting it before hand. I've now corrected this, but people will have downloaded the old bin and won't know to redownload it, unless we hard fail on trying to load it. In case you are unaware, the address bin is expected to be pre-sorted, and id lookups will randomly fail if it is not. Without this check, the old bin will cause a small, but annoying subset of users to pester you with bug reports that can't be reproduced because they're using the old bin.